### PR TITLE
feat: add prototype PF2e action builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# pharasma
+# Pharasmar Action Builder
+
+Prototype web app for building Pathfinder 2e action lists compatible with the Kobold Discord bot.
+
+## Development
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Set the `PASTEBIN_API_KEY` environment variable to enable automatic uploading to Pastebin. Otherwise, the app will display the generated commands for manual copy.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,51 @@
+import json
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, render_template, request
+import requests
+
+app = Flask(__name__)
+
+# Load actions and spells at startup
+BASE_DIR = Path(__file__).parent
+with open(BASE_DIR / "data" / "actions.json", "r", encoding="utf-8") as f:
+    ACTIONS = json.load(f)
+with open(BASE_DIR / "data" / "spells.json", "r", encoding="utf-8") as f:
+    SPELLS = json.load(f)
+
+
+def export_to_pastebin(content: str) -> str | None:
+    """Export content to Pastebin if credentials are configured."""
+    api_dev_key = os.getenv("PASTEBIN_API_KEY")
+    if not api_dev_key:
+        return None
+    data = {
+        "api_option": "paste",
+        "api_dev_key": api_dev_key,
+        "api_paste_code": content,
+    }
+    try:
+        resp = requests.post("https://pastebin.com/api/api_post.php", data=data, timeout=10)
+        if resp.status_code == 200:
+            return resp.text.strip()
+    except Exception:
+        pass
+    return None
+
+
+@app.route("/")
+def index():
+    return render_template("index.html", actions=ACTIONS, spells=SPELLS)
+
+
+@app.route("/export", methods=["POST"])
+def export_commands():
+    commands = request.json.get("commands", [])
+    content = "\n".join(commands)
+    paste_url = export_to_pastebin(content)
+    return jsonify({"paste_url": paste_url, "content": content})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/data/actions.json
+++ b/data/actions.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Strike", "command": "!strike"},
+  {"name": "Cast Spell", "command": "!cast ${spell}"}
+]

--- a/data/spells.json
+++ b/data/spells.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Magic Missile", "command": "!cast magic-missile"},
+  {"name": "Fireball", "command": "!cast fireball"}
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const exportBtn = document.getElementById('export-btn');
+  const resultDiv = document.getElementById('result');
+
+  exportBtn.addEventListener('click', async () => {
+    const commands = Array.from(document.querySelectorAll('.command:checked')).map(
+      el => el.value
+    );
+    const response = await fetch('/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ commands })
+    });
+    const data = await response.json();
+    if (data.paste_url) {
+      resultDiv.innerHTML = `<p>Pasted to <a href="${data.paste_url}" target="_blank">${data.paste_url}</a></p>`;
+    } else {
+      resultDiv.innerHTML = `<p>Pastebin not configured. Copy commands below:</p><pre>${data.content}</pre>`;
+    }
+  });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PF2e Action Builder</title>
+    <script src="/static/app.js" defer></script>
+</head>
+<body>
+    <h1>PF2e Action Builder</h1>
+    <h2>Actions</h2>
+    <ul>
+    {% for action in actions %}
+        <li>
+            <label>
+                <input type="checkbox" class="command" value="{{ action.command }}">
+                {{ action.name }}
+            </label>
+        </li>
+    {% endfor %}
+    </ul>
+
+    <h2>Spells</h2>
+    <ul>
+    {% for spell in spells %}
+        <li>
+            <label>
+                <input type="checkbox" class="command" value="{{ spell.command }}">
+                {{ spell.name }}
+            </label>
+        </li>
+    {% endfor %}
+    </ul>
+
+    <button id="export-btn">Export to Pastebin</button>
+    <div id="result"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build simple Flask web app to assemble Pathfinder 2e actions/spells
- allow exporting selected commands to Pastebin or manual copy

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6896b90cce94832987fdad7b4e19ebcd